### PR TITLE
Change contact email

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,7 @@ director: Jean-François Mangin
 webmaster: Edouard Duchesnay
 
 # Contacts
-email: edouard.duchesnay@cea.fr
+email: apply-gaia@cea.fr
 author:
 street_address:
 city:


### PR DESCRIPTION
Change the contact email from Edouard's personal address to a common one: apply-gaia@cea.fr