### PR TITLE
Small layout modification and publication of two job offers for N4Brain

### DIFF
--- a/_collections/_opportunities/engineer_n4brain_2025_1.html
+++ b/_collections/_opportunities/engineer_n4brain_2025_1.html
@@ -1,0 +1,58 @@
+---
+layout: page
+title: Linux system administrator
+inline_title: true
+cat: cati
+subcat: n4brain
+type: engineer
+date: 2025-10-22
+---
+<header class="main">
+    <h1>Administrateur Système Linux</h1>
+</header>
+<body>
+    <p>
+        <b>Type de contrat&nbsp;:</b> CDD 3 ans<br>
+        <b>Localisation&nbsp;:</b> Saclay<br>
+        <b>Expérience&nbsp;:</b> 2 à 5 ans minimum<br>
+    </p>
+    <p><b>Contexte :</b> 
+        De grands projets du Plan France 2030 (PEPR-PROPSY, IHU-IRDCE) placent les troubles cérébraux au cœur des priorités nationales. Ces initiatives produiront des données massives et multimodales (IRM, EEG, OMICs, questionnaires cliniques). 
+        Pour relever ce défi, le CEA, l’INSERM et l’INRIA unissent leurs forces à travers l’initiative N4Brain (Numeric for Brain), destinée à construire une plateforme numérique dotée de ressources de calcul et de stockage, dédiée à l’analyse par intelligence artificielle et à la réutilisation à long terme des données cérébrales. 
+        Cette plateforme sera mise à disposition de la communauté scientifique travaillant sur le cerveau, afin de favoriser le partage des données dans le respect du cadre réglementaire (RGPD) sur la protection des données de santé.
+        Le dispositif se distingue des entrepôts hospitaliers, centrés sur les soins quotidiens. En coordination avec le Health Data Hub, les hôpitaux, l’Institut Pasteur et le CNRS, N4Brain viendra compléter et renforcer l’écosystème existant.
+    </p>
+    <p><b>Localisation&nbsp;:</b>
+        Le poste est basé à NeuroSpin, centre de recherche français de référence en innovation sur l’imagerie cérébrale. NeuroSpin fait partie de la Direction de la Recherche Fondamentale (DRF) du Commissariat à l'énergie atomique (CEA Saclay) qui est membre de  l’Université Paris-Saclay premières université française du classement de Shanghai (15ᵉ au niveau mondial).
+    </p>
+    <b>Missions principales&nbsp;:</b>
+    <ul>
+        <li>Administrer et maintenir les serveurs Linux (Debian, CentOS, Ubuntu, etc.)</li>
+        <li>Développer et maintenir des scripts Bash et Python pour l’automatisation des tâches</li>
+        <li>Gérer les services web (Apache, Nginx) et assurer leur sécurité et leurs performances</li>
+        <li>Administration de système de stockage CEPH</li>
+        <li>Intégrer et administrer des annuaires LDAP pour la gestion des identités</li>
+        <li>Assurer la gestion, la sauvegarde et l’optimisation des bases de données (MySQL, PostgreSQL, etc.)</li>
+        <li>Participer à la mise en place de solutions de monitoring et de supervision</li>
+        <li>Collaborer avec les équipes DevOps et Sécurité pour garantir la fiabilité des infrastructures</li>
+    </ul>
+    <b>Compétences requises&nbsp;:</b>
+        <ul>
+        <li>Maîtrise avancée de l’environnement Linux</li>
+        <li>Solides compétences en scripting Bash et Python</li>
+        <li>Expérience avec les serveurs Apache et les annuaires LDAP</li>
+        <li>Connaissance des bases de données relationnelles</li>
+        <li>Bonne notions de sécurité système et réseau</li>
+        <li>Des connaissances sur le stockage distribué (type CEPH) serait un atout</li>
+        <li>Capacité à diagnostiquer et résoudre des incidents techniques</li>
+        </ul>
+    <b>Profil recherché&nbsp;:</b>
+        <ul>
+        <li>Bac + 5 en informatique</li>
+        <li>Autonomie, rigueur et sens de l’organisation</li>
+        <li>Esprit d’équipe et bonnes capacités de communication</li>
+        <li>Curiosité technique et envie d’apprendre</li>
+        <li>Capacité à travailler dans un environnement agile et dynamique</li>
+        </ul>
+    <p><b>Contact&nbsp;:</b> <a href="mailto:Yann Cointepas &lt;yann.cointepas@cea.fr&gt;">Yann Cointepas &lt;yann.cointepas@cea.fr&gt;</a></p>
+</body>

--- a/_collections/_opportunities/engineer_n4brain_2025_1.html
+++ b/_collections/_opportunities/engineer_n4brain_2025_1.html
@@ -16,9 +16,9 @@ date: 2025-10-22
         <b>Localisation&nbsp;:</b> Saclay<br>
         <b>Expérience&nbsp;:</b> 2 à 5 ans minimum<br>
     </p>
-    <p><b>Contexte :</b> 
-        De grands projets du Plan France 2030 (PEPR-PROPSY, IHU-IRDCE) placent les troubles cérébraux au cœur des priorités nationales. Ces initiatives produiront des données massives et multimodales (IRM, EEG, OMICs, questionnaires cliniques). 
-        Pour relever ce défi, le CEA, l’INSERM et l’INRIA unissent leurs forces à travers l’initiative N4Brain (Numeric for Brain), destinée à construire une plateforme numérique dotée de ressources de calcul et de stockage, dédiée à l’analyse par intelligence artificielle et à la réutilisation à long terme des données cérébrales. 
+    <p><b>Contexte :</b>
+        De grands projets du Plan France 2030 (PEPR-PROPSY, IHU-IRDCE) placent les troubles cérébraux au cœur des priorités nationales. Ces initiatives produiront des données massives et multimodales (IRM, EEG, OMICs, questionnaires cliniques).
+        Pour relever ce défi, le CEA, l’INSERM et l’INRIA unissent leurs forces à travers l’initiative N4Brain (Numeric for Brain), destinée à construire une plateforme numérique dotée de ressources de calcul et de stockage, dédiée à l’analyse par intelligence artificielle et à la réutilisation à long terme des données cérébrales.
         Cette plateforme sera mise à disposition de la communauté scientifique travaillant sur le cerveau, afin de favoriser le partage des données dans le respect du cadre réglementaire (RGPD) sur la protection des données de santé.
         Le dispositif se distingue des entrepôts hospitaliers, centrés sur les soins quotidiens. En coordination avec le Health Data Hub, les hôpitaux, l’Institut Pasteur et le CNRS, N4Brain viendra compléter et renforcer l’écosystème existant.
     </p>

--- a/_collections/_opportunities/engineer_n4brain_2025_2.html
+++ b/_collections/_opportunities/engineer_n4brain_2025_2.html
@@ -1,0 +1,76 @@
+---
+layout: page
+title: Development and integration engineer for brain research
+inline_title: true
+cat: cati
+subcat: n4brain
+type: engineer
+date: 2025-10-22
+---
+<header class="main">
+    <h1>Ingénieur développement et intégration pour la recherche sur le cerveau</h1>
+</header>
+<body>
+    <h2>Contexte</h2>
+    <p>De grands projets du Plan France 2030 (PEPR-PROPSY, IHU-IRDCE) placent les troubles cérébraux au cœur des priorités nationales. Ces initiatives produiront des données massives et multimodales (IRM, EEG, OMICs, questionnaires cliniques). Pour relever ce défi, le CEA, l’INSERM et l’INRIA unissent leurs forces à travers l’initiative N4Brain (Numeric for Brain), destinée à construire une plateforme numérique dotée de ressources de calcul et de stockage, dédiée à l’analyse par intelligence artificielle et à la réutilisation à long terme des données cérébrales. Cette plateforme sera mise à disposition de la communauté scientifique travaillant sur le cerveau, afin de favoriser le partage des données dans le respect du cadre réglementaire  sur la protection des données de santé.</p>
+    <p>Le poste sera localisé à NeuroSpin, le centre de recherche du CEA leader Français en innovation sur l’imagerie cérébrale au sein du plateau de Université Paris-Saclay.
+    <h2>Missions</h2>
+    <p>Au sein d’une équipe dynamique et pluridisciplinaire, vous contribuerez, selon vos compétences, à quatre grands chantiers&nbsp;:</p>
+    <ol>
+        <li><b>Développement du backend de l’outil d’administration</b>
+            <ul>
+                <li>Mise en œuvre et maintenance des mécanismes d’authentification et de gestion des droits d’accès.</li>
+                <li>Technologies et outils mobilisés : HTTP REST API, PostgreSQL, OpenID Connect, Keycloak, LDAP, authentification Linux, gestion des permissions sous Linux.</li>
+            </ul>
+        </li>
+        <li><b>Développement de l’interface utilisateur (frontend) de l’outil d’administration</b>
+            <ul>
+                <li>Création d’interfaces web ergonomiques pour la gestion des utilisateurs, des droits d’accès et l’attribution et le suivi des ressources.</li>
+                <li>Compétences requises : développement web, utilisation d’API REST.</li>
+            </ul>
+        </li>
+        <li><b>Déploiement et gestion d’environnements logiciels pour la recherche</b>
+            <ul>
+                <li>Implémentation d’une infrastructure offrant aux responsables d’étude la possibilité de configurer, déployer et maintenir durablement les environnements logiciels nécessaires à l’analyse des données.</li>
+                <li>Technologies : gestion de versions, packaging Linux, AppTainer, Docker, Conda ou Pixi, administration Linux.</li>
+            </ul>
+        </li>
+        <li><b>Intégration de logiciels et services dans la plateforme</b>
+            <ul>
+                <li>Téléchargement, installation, configuration et documentation de logiciels et services utilisés dans les analyses.</li>
+                <li>Compétences recherchées : scripting, administration Linux, rédaction de documentation technique.</li>
+            </ul>
+        </li>
+    </ol>
+
+    <h2>Profil recherché</h2>
+    <ul>
+        <li>Formation supérieure en informatique ou équivalent (Bac +5 minimum).</li>
+        <li>Expérience administration Linux et déploiement d’applications.</li>
+        <li>Maîtrise du développement web (HTML, CSS, JavaScript).</li>
+        <li>Expérience avec les API REST.</li>
+        <li>Connaissance des outils de conteneurisation et packaging (Docker, AppTainer, Conda/Pixi).</li>
+        <li>Expérience avec OpenID Connect et Keycloak.</li>
+    </ul>
+
+    <h2>Compétences requises</h2>
+    <ul>
+        <li>Sens de l’ergonomie et de l’expérience utilisateur.</li>
+        <li>Autonomie et sens de l’organisation.</li>
+        <li>Bonne capacité à travailler en équipe et à interagir avec des profils scientifiques.</li>
+        <li>Un expérience avec Python serait appréciée.</li>
+        <li>La connaissance des environnements de recherche en santé est un plus.</li>
+    </ul>
+    
+    <h2>Pourquoi nous rejoindre ?</h2>
+        <p>En rejoignant NeuroSpin et l’initiative N4Brain, vous intégrez un  environnement scientifique et technologique unique en Europe. Vous  bénéficierez de&nbsp;:</p>
+        <ul>
+            <li>Un projet à fort impact sociétal au cœur du Plan France 2030.</li>
+            <li>Des infrastructures numériques de pointe dédiées à la recherche sur le cerveau.</li>
+            <li>Une collaboration étroite avec des équipes interdisciplinaires (CEA, INSERM, INRIA, CNRS, hôpitaux, Institut Pasteur).</li>
+            <li>Un cadre de travail au sein du plateau Paris-Saclay, reconnu parmi les meilleurs pôles académiques mondiaux</li>
+        </ul>
+
+    <h2>Contact</h2> 
+    <p><a href="mailto:Yann Cointepas &lt;yann.cointepas@cea.fr&gt;">Yann Cointepas &lt;yann.cointepas@cea.fr&gt;</a></p>
+</body>

--- a/_collections/_opportunities/engineer_n4brain_2025_2.html
+++ b/_collections/_opportunities/engineer_n4brain_2025_2.html
@@ -61,7 +61,7 @@ date: 2025-10-22
         <li>Un expérience avec Python serait appréciée.</li>
         <li>La connaissance des environnements de recherche en santé est un plus.</li>
     </ul>
-    
+
     <h2>Pourquoi nous rejoindre ?</h2>
         <p>En rejoignant NeuroSpin et l’initiative N4Brain, vous intégrez un  environnement scientifique et technologique unique en Europe. Vous  bénéficierez de&nbsp;:</p>
         <ul>
@@ -71,6 +71,6 @@ date: 2025-10-22
             <li>Un cadre de travail au sein du plateau Paris-Saclay, reconnu parmi les meilleurs pôles académiques mondiaux</li>
         </ul>
 
-    <h2>Contact</h2> 
+    <h2>Contact</h2>
     <p><a href="mailto:Yann Cointepas &lt;yann.cointepas@cea.fr&gt;">Yann Cointepas &lt;yann.cointepas@cea.fr&gt;</a></p>
 </body>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -21,9 +21,11 @@
 
                 <!-- Content -->
                 <section>
+                    {% if page.inline_title == nil %}
                     <header class="main">
                         <h1>{{ page.title }}</h1>
                     </header>
+                    {% endif %}
 
                     {% if page.image %}
                         <span class="image main"><img src="{{site.url}}{{site.baseurl}}/{{page.image}}" alt="" /></span>

--- a/opportunities.md
+++ b/opportunities.md
@@ -29,7 +29,6 @@ For a spontaneous application do not hesitate to <a href="mailto:{{site.email}}"
     {% endfor %}
     {% assign jobs_valid = jobs_valid | push: listjobs %}
 {% endfor %}
-
 <div>
 {% assign i = 0 %}
 {% for item in jobs_array %}
@@ -56,7 +55,9 @@ For a spontaneous application do not hesitate to <a href="mailto:{{site.email}}"
             <div class="{{job.cat|replace: ' ', '-'}} {{job.subcat|replace: ' ', '-'}}">
               <p style="text-align: left; padding-left: 1em; margin: 0;">
                 &#x2022; {{job.title}} - {{job.profile}}
-                {% if job.ext_url %}
+                {% if job.layout == 'page' %}
+                  <a href="{{job.url}}" class="icon fa-cloud-download"><span class="label">Job</span></a>
+                {% elsif job.ext_url %}
                   <a href="{{job.ext_url}}" class="icon fa-cloud-download" target="_blank"><span class="label">Job</span></a>
                 {% elsif job.pdf %}
                   <a href="{{site.url}}{{site.baseurl}}/images/opportunities/{{job.pdf}}" class="icon fa-cloud-download" target="_blank"><span class="label">Job</span></a>


### PR DESCRIPTION
Layout modification include the possibility to avoid to automatically generate the title of a post if `inline_title: true` is included in the post metadata. This allows to have a different title in the list of posts and in the post page. In this PR, list of jobs is in english but N4Brain job offers are in french.

In "Opportunities" page, if a job uses the layout `page`, the link URL generated points to the job page that is part of the site, not to an external URL or pdf file.